### PR TITLE
added additional check for HTTPS

### DIFF
--- a/public/page_job.php
+++ b/public/page_job.php
@@ -68,7 +68,7 @@
 		$job_flag = true;
 		
 		$url = BASE_URL . URL_JOB .'/' . $id . '/' . $info['url_title'] . '/';
-		$current_url = (($_SERVER["HTTPS"] == "on") ? "https" : "http").'://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"];
+                $current_url = (isset($_SERVER["HTTPS"]) && !empty($_SERVER['HTTPS']) ? "https" : "http").'://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"];
 		
 		if ($current_url != $url) redirect_to($url, 301);
 		


### PR DESCRIPTION
I was getting an example of the following in my apache2 error log

```
[Wed May 28 23:59:12.012588 2014] [:error] [pid 25500] [client xx.xx.xx.xx:34445] PHP Notice:  Undefined index: HTTPS in /opt/jobberbase/public/page_job.php on line 71, referer: http://jobs.blah.blah/
```

This resolved it for me and I read where it may not always be set to "on" when it's HTTPS (I guess depending on the web server?).  Sending a pull request in case it helps in any way.
